### PR TITLE
Modify link color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -151,6 +151,10 @@ body::-webkit-scrollbar-thumb:hover {
   fill: red;
 }
 
+a {
+  color: #0254f1;
+}
+
 .qortal-link {
   text-decoration: none; /* Removes the underline */
   color: inherit; /* Inherits the color of the parent element */


### PR DESCRIPTION
This changes the color of links to allow for better readability.  Currently the default color used (#0000ee) can be hard to read against the background color.  The usual "Qortal blue" (#03a9f4) was tested, but appeared too pale against the background used for the "Q-Fund updates" section, so a midpoint between the two was chosen.  This has been published to QDN at `qortal://app/QM-Fund` to facilitate testing.